### PR TITLE
Fixes Package.swift file

### DIFF
--- a/Venator/Package.swift
+++ b/Venator/Package.swift
@@ -7,13 +7,18 @@ let package = Package(
     name: "Venator",
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser.git",
+                 from: "0.2.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Venator",
-            dependencies: []),
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]),
         .testTarget(
             name: "VenatorTests",
             dependencies: ["Venator"]),


### PR DESCRIPTION
**Reference Issue**: https://github.com/richiercyrus/Venator-Swift/issues/3

**Changes proposed in this pull request:**

 + Fix `Package.swift` so we can build and run Venator using only the SPM

**Details of the implementation:**

The file was broken, by a typo, and the dependencies to  the Swift
Argument Parser were missing. This commit addresses both issues.

Now Venator can be built and run using only the Swift Package Manager.